### PR TITLE
feat(nav): wire billing into dashboard nav + legal footer on all dashboard pages

### DIFF
--- a/app/dashboard/layout.tsx
+++ b/app/dashboard/layout.tsx
@@ -1,4 +1,5 @@
 import type { ReactNode } from 'react'
+import Link from 'next/link'
 import { OrganizationProvider } from '@/lib/context/OrganizationContext'
 import { VerticalNav, DynamicIsland } from '@/components/ui/DynamicIsland'
 import { Breadcrumb } from '@/components/ui/Breadcrumb'
@@ -35,6 +36,23 @@ export default function DashboardLayout({ children }: { children: ReactNode }) {
               {children}
             </div>
           </main>
+
+          {/* Legal footer */}
+          <footer className="flex items-center justify-center gap-4 py-4 px-6 border-t-[0.5px] border-white/[0.04]">
+            <Link
+              href="/privacy"
+              className="text-[11px] text-white/20 hover:text-white/40 transition-colors"
+            >
+              Privacy Policy
+            </Link>
+            <span className="text-white/10 text-[11px]">·</span>
+            <Link
+              href="/terms"
+              className="text-[11px] text-white/20 hover:text-white/40 transition-colors"
+            >
+              Terms of Service
+            </Link>
+          </footer>
         </div>
       </div>
     </OrganizationProvider>

--- a/lib/config/navigation.ts
+++ b/lib/config/navigation.ts
@@ -153,11 +153,11 @@ export const NAV_ITEMS: NavItemConfig[] = [
     showInDesktop: false, // Internal metrics, not client-facing
   },
   {
-    href: '/dashboard/pricing',
-    label: 'Pricing & Licenses',
-    shortLabel: 'Pricing',
+    href: '/dashboard/billing',
+    label: 'Billing',
+    shortLabel: 'Billing',
     icon: 'CreditCard',
-    matchPaths: ['/dashboard/pricing'],
+    matchPaths: ['/dashboard/billing', '/dashboard/pricing'],
     showInMobile: false, // Keep mobile nav focused
     showInDesktop: true,
   },


### PR DESCRIPTION
## Summary

- **Billing nav item**: The dashboard sidebar CreditCard icon now navigates to `/dashboard/billing` (plan status, payment history, Stripe portal) instead of `/dashboard/pricing`. The `matchPaths` include both `/dashboard/billing` and `/dashboard/pricing`, so the icon highlights on both pages. Users reach pricing through the "View Plans →" link on the billing page when they don't have a plan.
- **Legal footer on all dashboard pages**: Added a minimal footer (`Privacy Policy · Terms of Service`) to `app/dashboard/layout.tsx` — appears on every authenticated dashboard page. Required for Australian Privacy Act 1988 compliance (APP 1 — transparent handling of personal information).

## Test plan

- [ ] Sign in → check sidebar shows "Billing" (CreditCard icon) — click → lands on `/dashboard/billing`
- [ ] Navigate to `/dashboard/pricing` → CreditCard icon is still highlighted (matchPaths working)
- [ ] Any dashboard page (e.g. `/dashboard`) → subtle `Privacy Policy · Terms of Service` footer visible at bottom
- [ ] Click footer links → `/privacy` and `/terms` pages load correctly

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added a legal footer section to the dashboard with links to Privacy and Terms pages.

* **Updates**
  * Renamed the navigation item from "Pricing & Licenses" to "Billing" with an updated route path.
  * Maintained backward compatibility for the previous route.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->