### PR TITLE
fix(analysis): fix auto-run cron not processing validated queue items

### DIFF
--- a/app/api/analysis/auto-run/route.ts
+++ b/app/api/analysis/auto-run/route.ts
@@ -12,7 +12,7 @@
  */
 
 import { NextRequest, NextResponse } from 'next/server'
-import { createClient } from '@/lib/supabase/server'
+import { createServiceClient } from '@/lib/supabase/server'
 import { optionalConfig } from '@/lib/config/env'
 import { createLogger } from '@/lib/logger'
 
@@ -40,13 +40,13 @@ export async function POST(request: NextRequest) {
 
     log.info('Auto-analysis cron triggered')
 
-    const supabase = await createClient()
+    const supabase = await createServiceClient()
 
-    // Check analysis queue for pending jobs
+    // Check analysis queue for validated jobs ready to process
     const { data: queuedJobs, error: queueError } = await supabase
       .from('analysis_queue')
       .select('*')
-      .eq('status', 'pending')
+      .in('status', ['pending', 'validated'])
       .order('created_at', { ascending: true })
       .limit(MAX_BATCHES)
 
@@ -108,7 +108,7 @@ export async function POST(request: NextRequest) {
 
           await supabase
             .from('analysis_queue')
-            .update({ status: 'failed', error: String(err) })
+            .update({ status: 'failed', error_message: String(err) })
             .eq('id', job.id)
 
           failed++


### PR DESCRIPTION
## Summary
- **Bug 1**: Auto-run cron queried `.eq('status', 'pending')` but jobs in the queue are in `'validated'` state — cron never saw them. Fixed to `.in('status', ['pending', 'validated'])`
- **Bug 2**: Used `createClient()` (user auth with RLS) for a cron job. No user session = RLS blocks all rows. Fixed to `createServiceClient()`
- **Bug 3**: Column name `error` → `error_message` to match actual schema

## Root Cause
`get_queue_statistics()` confirmed 2 jobs stuck in `validated` state with `complete_count = 0` — nothing had ever processed. Combined effect of both bugs: even if status matched, RLS would block visibility.

## Impact
This unblocks the 0.8% → 100% automation pipeline. The 2 validated jobs will be picked up on the next cron run (2AM UTC daily).

## Test plan
- [ ] Next 2AM UTC cron run should process the 2 validated jobs
- [ ] `SELECT * FROM get_queue_statistics()` should show `complete_count > 0` after next run
- [ ] Manually trigger via `POST /api/analysis/auto-run` with `CRON_SECRET` to verify immediately

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Improvements**
  * The automatic analysis feature now processes both pending and validated jobs, expanding job coverage and improving processing efficiency.
  * Enhanced error message tracking for better monitoring and debugging of failed analysis jobs.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->