### PR TITLE
fix(email): rebrand sender domain from carsi.com.au to ato-ai.app

### DIFF
--- a/app/privacy/page.tsx
+++ b/app/privacy/page.tsx
@@ -94,7 +94,7 @@ const sections = [
       'Correction — Request correction of any inaccurate or incomplete personal information.',
       'Deletion — Request deletion of your personal information and all associated financial data. We will comply within 30 days unless we are legally required to retain certain records.',
       'Complaint — Lodge a complaint with the Office of the Australian Information Commissioner (OAIC) if you believe your privacy has been breached.',
-      'To exercise any of these rights, contact us at support@carsi.com.au with the subject line "Privacy Request".',
+      'To exercise any of these rights, contact us at support@ato-ai.app with the subject line "Privacy Request".',
     ],
   },
   {
@@ -119,7 +119,7 @@ const sections = [
     title: '10. Contact',
     content: [
       'If you have questions about this Privacy Policy or how we handle your data, please contact us:',
-      'Email: support@carsi.com.au',
+      'Email: support@ato-ai.app',
       'Operator: Disaster Recovery Qld (ABN 42 633 062 307)',
       'Location: Queensland, Australia',
     ],

--- a/app/terms/page.tsx
+++ b/app/terms/page.tsx
@@ -65,7 +65,7 @@ const sections = [
       'Core Analysis \u2014 $495 AUD: Includes standard tax analysis covering deduction recovery and compliance checks across connected financial data.',
       'Comprehensive Audit \u2014 $995 AUD: Includes full forensic audit covering R&D tax offsets (Division 355), Division 7A compliance, misclassified deductions, and 5-year historical analysis with detailed PDF/Excel reports.',
       'All payments are processed securely via Stripe. We do not store your payment card details.',
-      'Refund Policy \u2014 No refunds are available after an analysis report has been generated. If the Service fails to produce any analysis due to a technical error, you are entitled to a full refund. Contact support@carsi.com.au within 14 days of purchase.',
+      'Refund Policy \u2014 No refunds are available after an analysis report has been generated. If the Service fails to produce any analysis due to a technical error, you are entitled to a full refund. Contact support@ato-ai.app within 14 days of purchase.',
     ],
   },
   {
@@ -105,7 +105,7 @@ const sections = [
     id: 'termination',
     title: '8. Termination',
     content: [
-      'You may terminate your account at any time by contacting support@carsi.com.au or through your account settings.',
+      'You may terminate your account at any time by contacting support@ato-ai.app or through your account settings.',
       'We may terminate or suspend your access to the Service at any time, with or without cause, including for breach of these Terms.',
       'Upon termination, your right to use the Service ceases immediately. Your financial data will be deleted within 30 days of your request, subject to any legal retention requirements.',
       'Sections relating to intellectual property, limitation of liability, and governing law survive termination.',
@@ -125,7 +125,7 @@ const sections = [
     title: '10. Contact',
     content: [
       'For questions about these Terms of Service, please contact us:',
-      'Email: support@carsi.com.au',
+      'Email: support@ato-ai.app',
       'Operator: Disaster Recovery Qld (ABN 42 633 062 307)',
       'Location: Queensland, Australia',
     ],

--- a/lib/alerts/email-notifier.ts
+++ b/lib/alerts/email-notifier.ts
@@ -139,9 +139,9 @@ export async function sendAlertEmail(
 
     // Send email
     const [response] = await sgMail.send({
-      from: 'ATO Tax Optimizer <support@carsi.com.au>',
+      from: 'ATO Tax Optimizer <support@ato-ai.app>',
       to: recipientEmail,
-      replyTo: 'phill.m@carsi.com.au',
+      replyTo: 'support@ato-ai.app',
       subject: `${config.icon} ${alert.title}`,
       html: `
         <!DOCTYPE html>

--- a/lib/email/resend-client.ts
+++ b/lib/email/resend-client.ts
@@ -21,8 +21,8 @@ function ensureSendGridInit(): void {
 }
 
 // Default sender (must be verified in SendGrid)
-const DEFAULT_FROM_EMAIL = 'ATO Tax Optimizer <support@carsi.com.au>'
-const DEFAULT_REPLY_TO = 'phill.m@carsi.com.au'
+const DEFAULT_FROM_EMAIL = 'ATO Tax Optimizer <support@ato-ai.app>'
+const DEFAULT_REPLY_TO = 'support@ato-ai.app'
 
 export interface SendInvitationEmailParams {
   to: string

--- a/lib/email/send-invitation.ts
+++ b/lib/email/send-invitation.ts
@@ -31,8 +31,8 @@ function ensureSendGridInit(): void {
 }
 
 // Sender (must be verified in SendGrid)
-const FROM_EMAIL = 'ATO Tax Optimizer <support@carsi.com.au>'
-const REPLY_TO = 'phill.m@carsi.com.au'
+const FROM_EMAIL = 'ATO Tax Optimizer <support@ato-ai.app>'
+const REPLY_TO = 'support@ato-ai.app'
 
 export interface SendInvitationEmailParams {
   to: string // Invitee email address

--- a/lib/reports/email-delivery.ts
+++ b/lib/reports/email-delivery.ts
@@ -52,11 +52,11 @@ export async function sendReportEmail(
 ): Promise<{ id: string; success: boolean }> {
   try {
     const msg: sgMail.MailDataRequired = {
-      from: config.from || 'ATO Tax Optimizer <support@carsi.com.au>',
+      from: config.from || 'ATO Tax Optimizer <support@ato-ai.app>',
       to: Array.isArray(config.to) ? config.to : [config.to],
       subject: config.subject,
       html: htmlContent,
-      replyTo: config.replyTo || 'phill.m@carsi.com.au',
+      replyTo: config.replyTo || 'support@ato-ai.app',
       cc: config.cc ? (Array.isArray(config.cc) ? config.cc : [config.cc]) : undefined,
       bcc: config.bcc ? (Array.isArray(config.bcc) ? config.bcc : [config.bcc]) : undefined,
       attachments: attachments.map((att) => ({


### PR DESCRIPTION
## Summary

- Replaces all hardcoded `support@carsi.com.au` FROM/reply-to addresses across 4 email-sending modules with `support@ato-ai.app`
- Updates `/terms` and `/privacy` legal pages to reference `support@ato-ai.app` as the contact address
- Establishes a distinct product identity for ATO Tax Optimizer separate from the CARSI business domain

## Files changed

| File | Change |
|------|--------|
| `lib/email/resend-client.ts` | `DEFAULT_FROM_EMAIL` → `support@ato-ai.app` |
| `lib/email/send-invitation.ts` | `FROM_EMAIL` + `REPLY_TO` → `support@ato-ai.app` |
| `lib/alerts/email-notifier.ts` | `from` + `replyTo` → `support@ato-ai.app` |
| `lib/reports/email-delivery.ts` | `from` + `replyTo` → `support@ato-ai.app` |
| `app/terms/page.tsx` | Contact email → `support@ato-ai.app` |
| `app/privacy/page.tsx` | Contact email → `support@ato-ai.app` |

## DNS

SPF TXT record `v=spf1 include:sendgrid.net ~all` added to `ato-ai.app` in Vercel DNS.

## Test plan

- [ ] Send a test report email — verify FROM shows `ATO Tax Optimizer <support@ato-ai.app>`
- [ ] Visit `/terms` and `/privacy` — verify contact email shows `support@ato-ai.app`
- [ ] Verify SPF propagation: `nslookup -type=TXT ato-ai.app`

## Pending (manual)

- Create SendGrid account → authenticate domain `ato-ai.app` → obtain DKIM CNAME records → add to Vercel DNS → add `SENDGRID_API_KEY` to Vercel env vars

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated system-wide email addresses for notifications, support inquiries, and contact information across privacy policies, terms of service, and automated communications to ensure consistent communication channels.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->