### PR TITLE
feat(branding): add ATO Tax Optimizer nav to homepage

### DIFF
--- a/app/page.tsx
+++ b/app/page.tsx
@@ -70,6 +70,16 @@ export default function Home() {
       <BreadcrumbSchema />
 
       <main>
+        {/* ── Brand Nav ── */}
+        <nav className="px-4 sm:px-6 lg:px-8 pt-6 pb-2">
+          <div className="max-w-4xl mx-auto w-full flex items-center gap-2">
+            <Shield className="w-3.5 h-3.5" style={{ color: SPECTRAL.cyan }} />
+            <span className="text-[11px] uppercase tracking-[0.4em] font-medium text-white/70">
+              ATO Tax Optimizer
+            </span>
+          </div>
+        </nav>
+
         {/* ── Hero ── */}
         <header className="min-h-screen flex flex-col justify-center px-4 sm:px-6 lg:px-8 py-16">
           <div className="max-w-4xl mx-auto w-full text-center">


### PR DESCRIPTION
## Summary
- Adds visible "ATO Tax Optimizer" brand name to homepage nav bar
- Fixes Google Cloud Platform OAuth branding verification (app name must appear as visible text on the homepage)
- Uses Scientific Luxury design system: `text-[11px] uppercase tracking-[0.4em]`, spectral cyan accent

## Why
GCP Auth Platform branding check requires the app name to appear as visible text on the homepage. The existing homepage only had marketing copy in the `<h1>` — not the app name itself. This causes GCP's automated branding check to fail with "app name does not match".

## Test plan
- [ ] Visit https://ato-ai.app — confirm "ATO Tax Optimizer" appears in the top nav
- [ ] Confirm GCP Auth Platform branding verification passes after deployment

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added a branded navigation section to the page featuring an icon and product name with consistent styling.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->