### PR TITLE
chore(deps): refresh pnpm-lock.yaml (3-week CI rot fix)

### DIFF
--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -20,6 +20,9 @@ importers:
       '@sentry/nextjs':
         specifier: ^10.38.0
         version: 10.38.0(@opentelemetry/context-async-hooks@2.5.0(@opentelemetry/api@1.9.0))(@opentelemetry/core@2.5.0(@opentelemetry/api@1.9.0))(@opentelemetry/sdk-trace-base@2.5.0(@opentelemetry/api@1.9.0))(next@16.1.3(@babel/core@7.29.0)(@opentelemetry/api@1.9.0)(@playwright/test@1.58.2)(react-dom@19.2.3(react@19.2.3))(react@19.2.3))(react@19.2.3)(webpack@5.105.1)
+      '@stripe/stripe-js':
+        specifier: ^9.0.0
+        version: 9.5.0
       '@supabase/ssr':
         specifier: ^0.8.0
         version: 0.8.0(@supabase/supabase-js@2.95.3)
@@ -1505,6 +1508,10 @@ packages:
 
   '@standard-schema/utils@0.3.0':
     resolution: {integrity: sha512-e7Mew686owMaPJVNNLs55PUvgz371nKgwsc4vxE49zsODpJEnxgxRo2y/OKrqueavXgZNMDVj3DdHFlaSAeU8g==}
+
+  '@stripe/stripe-js@9.5.0':
+    resolution: {integrity: sha512-dTQWkJRw5lhcQipPuw6qZRBK2zY5eWWZ1Srw9mSjhIXSLdsNYO3uaIV+YRMkI0/tB/D7yQdHYStrcZrbeHI5Jg==}
+    engines: {node: '>=12.16'}
 
   '@supabase/auth-js@2.95.3':
     resolution: {integrity: sha512-vD2YoS8E2iKIX0F7EwXTmqhUpaNsmbU6X2R0/NdFcs02oEfnHyNP/3M716f3wVJ2E5XHGiTFXki6lRckhJ0Thg==}
@@ -6137,6 +6144,8 @@ snapshots:
   '@standard-schema/spec@1.1.0': {}
 
   '@standard-schema/utils@0.3.0': {}
+
+  '@stripe/stripe-js@9.5.0': {}
 
   '@supabase/auth-js@2.95.3':
     dependencies:


### PR DESCRIPTION
## Summary
Refresh `pnpm-lock.yaml` to match current `package.json`. ATO main CI has been red since 2026-04-26 due to `ERR_PNPM_OUTDATED_LOCKFILE` on every frozen-lockfile install.

## Root cause
`@stripe/stripe-js@^9.0.0` was declared in `package.json` dependencies but never resolved into the lockfile. Every `pnpm install --frozen-lockfile` step in CI rejected the mismatch.

## Verification
- Local: `rm -rf node_modules && pnpm install --frozen-lockfile` succeeds (pnpm 9.15.9 + Node 20.20.2, matching CI env)
- Diff: lockfile-only, +9 lines, `lockfileVersion: '9.0'` preserved
- No `package.json` modifications

## Unblocks
- Closes the cascade that was failing Typecheck & Lint, Unit & Integration, E2E, Critical Tests, Dependency Review, NPM Audit
- Required prerequisite for Deepsec PR #8 to merge

Generated with Claude Code (Opus 4.7)