### PR TITLE
test(env): align GOOGLE_AI_MODEL default expectation with current source

### DIFF
--- a/tests/unit/config/env.test.ts
+++ b/tests/unit/config/env.test.ts
@@ -84,7 +84,7 @@ describe('optionalConfig', () => {
     }))
     const { optionalConfig } = await import('@/lib/config/env')
 
-    expect(optionalConfig.googleAiModel).toBe('gemini-2.0-flash')
+    expect(optionalConfig.googleAiModel).toBe('gemini-3-flash-preview')
 
     if (saved !== undefined) process.env.GOOGLE_AI_MODEL = saved
   })


### PR DESCRIPTION
## Why this PR

Every main-branch CI Pipeline run has been red on the same single test for the last several pushes:

\`\`\`
AssertionError: expected 'gemini-3-flash-preview' to be 'gemini-2.0-flash'
 ❯ tests/unit/config/env.test.ts:87:42
\`\`\`

In commit \`1eb97e0\` (\`feat(ai): migrate default model to Gemini 3 Flash\`) the default at \`lib/config/env.ts:192\` was bumped:

\`\`\`ts
googleAiModel: getOptionalEnv('GOOGLE_AI_MODEL', 'gemini-3-flash-preview'),
\`\`\`

…but the matching assertion in the test wasn't updated. Bringing the test back in sync with the source is the one-line fix.

## What changed

- \`tests/unit/config/env.test.ts:87\` — expectation updated from \`'gemini-2.0-flash'\` to \`'gemini-3-flash-preview'\`.

That's all. The other 16 tests in this file (and the other 85 test files in the suite) already pass.

## Test plan

- [ ] CI Pipeline \`Unit & Integration Tests\` job goes green on this PR.
- [ ] After merge: next main-branch run is green for this gate.

🤖 Generated with [Claude Code](https://claude.com/claude-code)