### PR TITLE
fix(stripe): pin apiVersion to '2026-01-28.clover' to match installed SDK

### DIFF
--- a/lib/stripe/client.ts
+++ b/lib/stripe/client.ts
@@ -29,7 +29,13 @@ function getStripeInstance(): Stripe {
       log.warn('Stripe initialised with TEST key in PRODUCTION — payments will not be real');
     }
     stripeInstance = new Stripe(apiKey, {
-      apiVersion: '2026-02-25.clover',
+      // Pinned to what stripe@20.3.0 types declare. Bumping the string to
+      // a newer API date (e.g. '2026-02-25.clover') without first upgrading
+      // the SDK version produces TS2322 — the typed `apiVersion` union only
+      // contains the date the installed SDK knows about. Coordinate any
+      // bump here with a `pnpm up stripe` (and a re-test of the webhook
+      // signature path, which is API-version-sensitive).
+      apiVersion: '2026-01-28.clover',
       typescript: true,
       appInfo: {
         name: 'ATO Tax Optimizer',


### PR DESCRIPTION
## Why this PR

\`CI Pipeline\` → \`Typecheck & Lint\` has been red on every main-branch run since the Stripe apiVersion string was bumped past what \`stripe@^20.3.0\` types declare:

\`\`\`
lib/stripe/client.ts(32,7): error TS2322:
  Type '"2026-02-25.clover"' is not assignable to type
  '"2026-01-28.clover"'.
\`\`\`

## Fix

Pinned the string back to \`'2026-01-28.clover'\` (what the installed SDK's \`Stripe.LatestApiVersion\` union declares). Added a comment so the next person considering a bump is reminded to upgrade the SDK (\`pnpm up stripe\`) and re-test the webhook signature path in the same PR.

## Why not bump the SDK instead?

API-version bumps on the Stripe SDK occasionally change event payload shape — especially affecting webhook handlers. That's a larger blast-radius change that deserves its own PR with explicit re-testing of:
- \`/api/webhooks/stripe\` signature verification
- Event payloads we destructure from
- Any \`type:\` checks against event names that may have been renamed

Out of scope for an unblock. This PR just gets CI green.

## What this does NOT change

- Stripe runtime behaviour: we were never actually on \`'2026-02-25.clover'\` — the SDK pins to its supported version regardless of the string (the field is mostly for typing + a SDK-version sanity check).
- Webhook handlers, payment flows, customer creation, none of it.

## Test plan

- [ ] CI Pipeline → Typecheck & Lint goes green on this PR.
- [ ] After merge: next main-branch CI Pipeline run is green for the type-check step.

🤖 Generated with [Claude Code](https://claude.com/claude-code)