### PR TITLE
fix(docs): correct production URL from dead ato-blush.vercel.app to l…

### DIFF
--- a/ATO_PROJECT_STATUS.md
+++ b/ATO_PROJECT_STATUS.md
@@ -27,7 +27,7 @@
 - Historical transaction cache: **12,236 records**
 - AI analysis results storage
 
-**Production URL:** https://ato-blush.vercel.app
+**Production URL:** https://ato-ai.app
 **Status:** Live and fully operational
 
 **Recent Update (Jan 28, 2026):**
@@ -143,14 +143,14 @@ Build comprehensive tax reporting dashboard with:
 | Organizations Connected | 2 |
 | Transactions Imported | 12,236 |
 | AI Analysis Progress | 100 / 12,236 (0.8%) |
-| Deployment URL | https://ato-blush.vercel.app |
+| Deployment URL | https://ato-ai.app |
 
 ---
 
 ## 🚀 Production Deployment
 
 **Environment:** Vercel
-**URL:** https://ato-blush.vercel.app
+**URL:** https://ato-ai.app
 **Status:** ✅ Healthy
 
 **Recent Deployments:**
@@ -212,7 +212,7 @@ To complete the ATO project to 100%, the remaining task is to implement the Tax 
 ## 🔗 Resources
 
 - **Linear Project:** https://linear.app/unite-hub/project/ato-3f31f766c467/overview
-- **Production Site:** https://ato-blush.vercel.app
+- **Production Site:** https://ato-ai.app
 - **GitHub Repository:** https://github.com/CleanExpo/ATO
 - **Vercel Dashboard:** https://vercel.com/unite-group/ato/deployments
 

--- a/ENVIRONMENT_VARIABLES_SETUP.md
+++ b/ENVIRONMENT_VARIABLES_SETUP.md
@@ -52,7 +52,7 @@ Environment: ✅ Production only
 
 For Preview/Development:
 ```
-https://ato-blush.vercel.app
+https://ato-ai.app
 ```
 Environments: ✅ Preview + Development
 
@@ -132,7 +132,7 @@ Environment: ✅ Production only
 
 For Preview/Development:
 ```
-https://ato-blush.vercel.app/api/auth/google/callback
+https://ato-ai.app/api/auth/google/callback
 ```
 Environments: ✅ Preview + Development
 


### PR DESCRIPTION
…ive ato-ai.app

The ATO_PROJECT_STATUS.md and ENVIRONMENT_VARIABLES_SETUP.md referenced https://ato-blush.vercel.app as the production URL. That domain has been returning HTTP 404 for some time. The actual live production site is https://ato-ai.app (verified HTTP 200, 159KB body, serving the ATO Tax Optimizer homepage and /dashboard routes).

This fix:
  - Updates 4 references in ATO_PROJECT_STATUS.md
  - Updates 2 references in ENVIRONMENT_VARIABLES_SETUP.md
  - Leaves the other 6 occurrences in ENVIRONMENT_VARIABLES_SETUP.md that already correctly reference ato-ai.app unchanged
  - Touches no code, no live config, no email templates, no Stripe webhooks

The 8 occurrences of ato-optimizer.com.au in the live code (stripe, email, lighthouse workflow) and the 27+ occurrences in docs/archive/ are left for a separate decision per file.

## Summary
<!-- 1-3 sentences: what changed and why -->

## Registry impact
- [ ] No registry change required
- [ ] Updated `.portfolio/PORTFOLIO.yaml` (only Unite-Hub holds the registry)
- [ ] N/A — this repo is not Unite-Hub (no registry here)

## Sandbox testing
- [ ] Tested on sandbox deployment (URL: ____________)
- [ ] N/A — not user-facing / config change only

## Verification
- [ ] Type checks pass (`npm run typecheck` or equivalent)
- [ ] Tests pass (or none applicable)
- [ ] Build succeeds (`npm run build`)
- [ ] Manual smoke test of changed feature

## Screenshots / recordings
<!-- For UI changes -->

## Rollback plan
<!-- How to revert if this breaks prod -->
