### PR TITLE
feat: /api/v1/connections/status readiness manifest (UNI-2139 slice 2)

### DIFF
--- a/app/api/v1/connections/status/route.ts
+++ b/app/api/v1/connections/status/route.ts
@@ -1,0 +1,16 @@
+/**
+ * GET /api/v1/connections/status
+ *
+ * Public, secret-free readiness manifest for Unite-Group Mission Control to
+ * poll. Reports connection state derived from env-var presence only — never
+ * from secret values, and no secret material is ever returned.
+ */
+
+import { NextResponse } from 'next/server'
+import { buildAtoAppConnectionStatus } from '@/lib/connections/status'
+
+export const dynamic = 'force-dynamic'
+
+export async function GET() {
+  return NextResponse.json(buildAtoAppConnectionStatus())
+}

--- a/lib/connections/status.ts
+++ b/lib/connections/status.ts
@@ -1,0 +1,223 @@
+export type AtoAppConnectionId =
+  | "supabase"
+  | "xero"
+  | "myob"
+  | "quickbooks"
+  | "google_ai"
+  | "stripe"
+  | "sendgrid"
+  | "linear"
+  | "abr"
+  | "sentry"
+  | "unite_group";
+
+export type AtoAppConnectionState =
+  | "connected"
+  | "ready"
+  | "mock"
+  | "blocked"
+  | "unknown";
+
+export type AtoAppConnection = {
+  id: AtoAppConnectionId;
+  label: string;
+  state: AtoAppConnectionState;
+  safeForMissionControl: boolean;
+  detail: string;
+  endpoint?: string;
+  nextAction?: string;
+};
+
+export type AtoAppConnectionStatus = {
+  source: "ato-app:connection-status";
+  generatedAt: string;
+  project: {
+    slug: "ato-app";
+    repo: "CleanExpo/ATO";
+    service: "ato-app-web";
+    environment: string;
+  };
+  summary: Record<AtoAppConnectionState, number> & { total: number };
+  connections: AtoAppConnection[];
+};
+
+function envSet(name: string, env: NodeJS.ProcessEnv): boolean {
+  return Boolean(env[name]?.trim());
+}
+
+function connectionSummary(
+  connections: AtoAppConnection[],
+): AtoAppConnectionStatus["summary"] {
+  return {
+    total: connections.length,
+    connected: connections.filter((c) => c.state === "connected").length,
+    ready: connections.filter((c) => c.state === "ready").length,
+    mock: connections.filter((c) => c.state === "mock").length,
+    blocked: connections.filter((c) => c.state === "blocked").length,
+    unknown: connections.filter((c) => c.state === "unknown").length,
+  };
+}
+
+/**
+ * Presence-only readiness manifest for Unite-Group Mission Control polling.
+ * States are derived from env-var presence, never from secret values, and no
+ * secret material is ever included in the payload. "connected" is reserved
+ * for infrastructure the app cannot boot without (per lib/config/env.ts,
+ * only SUPABASE_SERVICE_ROLE_KEY is a hard-required env var); integrations
+ * whose live use is still gated (Xero/MYOB/QuickBooks OAuth, billing, email,
+ * AI, ABR lookup, PM sync) report "ready" at best.
+ */
+export function buildAtoAppConnectionStatus(
+  env: NodeJS.ProcessEnv = process.env,
+  now = new Date().toISOString(),
+): AtoAppConnectionStatus {
+  const environment = env.VERCEL_ENV?.trim() || env.NODE_ENV?.trim() || "development";
+
+  const supabaseReady =
+    envSet("NEXT_PUBLIC_SUPABASE_URL", env) &&
+    envSet("NEXT_PUBLIC_SUPABASE_ANON_KEY", env) &&
+    envSet("SUPABASE_SERVICE_ROLE_KEY", env);
+  const xeroReady = envSet("XERO_CLIENT_ID", env) && envSet("XERO_CLIENT_SECRET", env);
+  const myobReady = envSet("MYOB_CLIENT_ID", env) && envSet("MYOB_CLIENT_SECRET", env);
+  const quickbooksReady =
+    envSet("QUICKBOOKS_CLIENT_ID", env) && envSet("QUICKBOOKS_CLIENT_SECRET", env);
+  const googleAiReady = envSet("GOOGLE_AI_API_KEY", env);
+  const stripeReady = envSet("STRIPE_SECRET_KEY", env);
+  const stripeWebhookReady = envSet("STRIPE_WEBHOOK_SECRET", env);
+  const sendgridReady = envSet("SENDGRID_API_KEY", env);
+  const linearReady = envSet("LINEAR_API_KEY", env) && envSet("LINEAR_TEAM_ID", env);
+  const abrReady = envSet("ABR_GUID", env);
+  const sentryReady = envSet("NEXT_PUBLIC_SENTRY_DSN", env);
+
+  const connections: AtoAppConnection[] = [
+    {
+      id: "supabase",
+      label: "Supabase",
+      state: supabaseReady ? "connected" : "blocked",
+      safeForMissionControl: true,
+      detail: supabaseReady
+        ? "Supabase URL, anon key, and service role key are present."
+        : "NEXT_PUBLIC_SUPABASE_URL, NEXT_PUBLIC_SUPABASE_ANON_KEY, and SUPABASE_SERVICE_ROLE_KEY are required to boot.",
+      nextAction: supabaseReady ? undefined : "Set the Supabase env trio.",
+    },
+    {
+      id: "xero",
+      label: "Xero accounting sync",
+      state: xeroReady ? "ready" : "blocked",
+      safeForMissionControl: true,
+      detail: xeroReady
+        ? "Xero OAuth credential pair present; live sync remains user-connect-gated."
+        : "XERO_CLIENT_ID and XERO_CLIENT_SECRET are required for Xero sync.",
+      nextAction: xeroReady ? undefined : "Provision Xero OAuth app credentials.",
+    },
+    {
+      id: "myob",
+      label: "MYOB accounting sync",
+      state: myobReady ? "ready" : "blocked",
+      safeForMissionControl: true,
+      detail: myobReady
+        ? "MYOB OAuth credential pair present; live sync remains user-connect-gated."
+        : "MYOB_CLIENT_ID and MYOB_CLIENT_SECRET are required for MYOB sync.",
+      nextAction: myobReady ? undefined : "Provision MYOB OAuth app credentials.",
+    },
+    {
+      id: "quickbooks",
+      label: "QuickBooks Online sync",
+      state: quickbooksReady ? "ready" : "blocked",
+      safeForMissionControl: true,
+      detail: quickbooksReady
+        ? "QuickBooks OAuth credential pair present; live sync remains user-connect-gated."
+        : "QUICKBOOKS_CLIENT_ID and QUICKBOOKS_CLIENT_SECRET are required for QuickBooks sync.",
+      nextAction: quickbooksReady ? undefined : "Provision QuickBooks OAuth app credentials.",
+    },
+    {
+      id: "google_ai",
+      label: "Google AI (Gemini analysis)",
+      state: googleAiReady ? "ready" : "blocked",
+      safeForMissionControl: true,
+      detail: googleAiReady
+        ? "Gemini API key present; AI analysis features can run (billing applies on use)."
+        : "GOOGLE_AI_API_KEY is not set — AI analysis features degrade.",
+      nextAction: googleAiReady ? undefined : "Set GOOGLE_AI_API_KEY.",
+    },
+    {
+      id: "stripe",
+      label: "Payments (Stripe)",
+      state: stripeReady ? "ready" : "blocked",
+      safeForMissionControl: true,
+      detail: stripeReady
+        ? stripeWebhookReady
+          ? "Stripe secret and webhook secret present; production checkout remains human-gated."
+          : "Stripe secret present but STRIPE_WEBHOOK_SECRET is missing — webhooks will fail."
+        : "STRIPE_SECRET_KEY is not set.",
+      nextAction: stripeReady
+        ? stripeWebhookReady
+          ? undefined
+          : "Set STRIPE_WEBHOOK_SECRET."
+        : "Set the Stripe key pair.",
+    },
+    {
+      id: "sendgrid",
+      label: "Transactional email (SendGrid)",
+      state: sendgridReady ? "ready" : "blocked",
+      safeForMissionControl: true,
+      detail: sendgridReady
+        ? "SendGrid key present; report and invitation sends remain policy-gated."
+        : "SENDGRID_API_KEY is not set — no transactional email.",
+      nextAction: sendgridReady ? undefined : "Set SENDGRID_API_KEY.",
+    },
+    {
+      id: "linear",
+      label: "Linear project sync",
+      state: linearReady ? "ready" : "blocked",
+      safeForMissionControl: true,
+      detail: linearReady
+        ? "Linear key and team id present for task sync."
+        : "LINEAR_API_KEY and LINEAR_TEAM_ID are required to sync tasks.",
+      nextAction: linearReady ? undefined : "Set the Linear intake env pair.",
+    },
+    {
+      id: "abr",
+      label: "Australian Business Register lookup",
+      state: abrReady ? "ready" : "blocked",
+      safeForMissionControl: true,
+      detail: abrReady
+        ? "ABR GUID present; ABN validation and entity lookup can run."
+        : "ABR_GUID is not set — ABN validation is unavailable.",
+      nextAction: abrReady ? undefined : "Set ABR_GUID.",
+    },
+    {
+      id: "sentry",
+      label: "Error monitoring (Sentry)",
+      state: sentryReady ? "connected" : "unknown",
+      safeForMissionControl: true,
+      detail: sentryReady
+        ? "Sentry DSN present; client/edge/server configs ship in this repo."
+        : "No Sentry DSN detected — errors are not being reported.",
+      nextAction: sentryReady ? undefined : "Set NEXT_PUBLIC_SENTRY_DSN.",
+    },
+    {
+      id: "unite_group",
+      label: "Unite-Group Mission Control",
+      state: "ready",
+      safeForMissionControl: true,
+      detail:
+        "This manifest is designed for Unite-Group to poll and show ATO-APP readiness without secrets.",
+      endpoint: "/api/v1/connections/status",
+      nextAction: "Add this endpoint to the Unite-Group project registry.",
+    },
+  ];
+
+  return {
+    source: "ato-app:connection-status",
+    generatedAt: now,
+    project: {
+      slug: "ato-app",
+      repo: "CleanExpo/ATO",
+      service: "ato-app-web",
+      environment,
+    },
+    summary: connectionSummary(connections),
+    connections,
+  };
+}

--- a/tests/unit/connections/status.test.ts
+++ b/tests/unit/connections/status.test.ts
@@ -1,0 +1,94 @@
+import { describe, it, expect } from 'vitest'
+import { buildAtoAppConnectionStatus } from '@/lib/connections/status'
+
+const EMPTY_ENV = {} as unknown as NodeJS.ProcessEnv
+
+const FULL_ENV = {
+  VERCEL_ENV: 'production',
+  NEXT_PUBLIC_SUPABASE_URL: 'https://example.supabase.co',
+  NEXT_PUBLIC_SUPABASE_ANON_KEY: 'anon-key-value',
+  SUPABASE_SERVICE_ROLE_KEY: 'service-role-value',
+  XERO_CLIENT_ID: 'xero-client-id',
+  XERO_CLIENT_SECRET: 'xero-client-secret-value',
+  MYOB_CLIENT_ID: 'myob-client-id',
+  MYOB_CLIENT_SECRET: 'myob-client-secret-value',
+  QUICKBOOKS_CLIENT_ID: 'qb-client-id',
+  QUICKBOOKS_CLIENT_SECRET: 'qb-client-secret-value',
+  GOOGLE_AI_API_KEY: 'google-ai-key-value',
+  STRIPE_SECRET_KEY: 'sk_test_value',
+  STRIPE_WEBHOOK_SECRET: 'whsec_value',
+  SENDGRID_API_KEY: 'SG.sendgrid-value',
+  LINEAR_API_KEY: 'lin_api_value',
+  LINEAR_TEAM_ID: 'UNI',
+  ABR_GUID: 'abr-guid-value',
+  NEXT_PUBLIC_SENTRY_DSN: 'https://abc@sentry.example/1',
+} as unknown as NodeJS.ProcessEnv
+
+describe('buildAtoAppConnectionStatus', () => {
+  it('reports blocked/unknown states when env is empty', () => {
+    const status = buildAtoAppConnectionStatus(EMPTY_ENV, '2026-07-02T00:00:00.000Z')
+    const byId = Object.fromEntries(status.connections.map((c) => [c.id, c]))
+
+    expect(byId.supabase.state).toBe('blocked')
+    expect(byId.xero.state).toBe('blocked')
+    expect(byId.myob.state).toBe('blocked')
+    expect(byId.quickbooks.state).toBe('blocked')
+    expect(byId.google_ai.state).toBe('blocked')
+    expect(byId.stripe.state).toBe('blocked')
+    expect(byId.sendgrid.state).toBe('blocked')
+    expect(byId.linear.state).toBe('blocked')
+    expect(byId.abr.state).toBe('blocked')
+    expect(byId.sentry.state).toBe('unknown')
+    expect(byId.unite_group.state).toBe('ready')
+    expect(status.summary.total).toBe(status.connections.length)
+    expect(status.summary.blocked).toBeGreaterThan(0)
+  })
+
+  it('reports connected/ready states with a fully configured env', () => {
+    const status = buildAtoAppConnectionStatus(FULL_ENV, '2026-07-02T00:00:00.000Z')
+    const byId = Object.fromEntries(status.connections.map((c) => [c.id, c]))
+
+    expect(byId.supabase.state).toBe('connected')
+    expect(byId.sentry.state).toBe('connected')
+    expect(byId.xero.state).toBe('ready')
+    expect(byId.myob.state).toBe('ready')
+    expect(byId.quickbooks.state).toBe('ready')
+    expect(byId.google_ai.state).toBe('ready')
+    expect(byId.stripe.state).toBe('ready')
+    expect(byId.sendgrid.state).toBe('ready')
+    expect(byId.linear.state).toBe('ready')
+    expect(byId.abr.state).toBe('ready')
+    expect(status.project.environment).toBe('production')
+    expect(status.summary.blocked).toBe(0)
+  })
+
+  it('flags a missing Stripe webhook secret without blocking', () => {
+    const env = { ...FULL_ENV, STRIPE_WEBHOOK_SECRET: '' } as NodeJS.ProcessEnv
+    const status = buildAtoAppConnectionStatus(env, '2026-07-02T00:00:00.000Z')
+    const stripe = status.connections.find((c) => c.id === 'stripe')
+
+    expect(stripe?.state).toBe('ready')
+    expect(stripe?.nextAction).toBe('Set STRIPE_WEBHOOK_SECRET.')
+  })
+
+  it('never leaks secret values into the payload', () => {
+    const status = buildAtoAppConnectionStatus(FULL_ENV, '2026-07-02T00:00:00.000Z')
+    const serialized = JSON.stringify(status)
+
+    for (const secret of [
+      'xero-client-secret-value',
+      'myob-client-secret-value',
+      'qb-client-secret-value',
+      'google-ai-key-value',
+      'sk_test_value',
+      'whsec_value',
+      'SG.sendgrid-value',
+      'lin_api_value',
+      'anon-key-value',
+      'service-role-value',
+      'abr-guid-value',
+    ]) {
+      expect(serialized).not.toContain(secret)
+    }
+  })
+})


### PR DESCRIPTION
## Summary

Adds a public, secret-free readiness endpoint — `GET /api/v1/connections/status` — so Unite-Group Mission Control can poll ATO-APP's integration health. Mirrors the shape and standards of the RestoreAssist reference implementation (RestoreAssist#1634).

All connection states are derived from **env-var presence only** — no secret values are ever read, compared, or returned. `safeForMissionControl: true` on every entry; no auth required (matches the existing public `/api/health` convention in this repo).

## Connections included and why

Sourced from this repo's actual integrations (`.env.example`, `.env.production.example`, `lib/config/env.ts`) — no invented integrations.

| id | state logic | why |
|---|---|---|
| `supabase` | connected / blocked | `lib/config/env.ts` only hard-requires `SUPABASE_SERVICE_ROLE_KEY` to boot — the sole boot-critical infra dependency. Also checks the public URL/anon key pair. |
| `xero` | ready / blocked | Xero OAuth sync — user-connect-gated, optional at boot. |
| `myob` | ready / blocked | MYOB OAuth sync — user-connect-gated, optional at boot. |
| `quickbooks` | ready / blocked | QuickBooks OAuth sync — user-connect-gated, optional at boot. |
| `google_ai` | ready / blocked | Gemini API key for AI tax analysis — billing-gated on use. |
| `stripe` | ready / blocked | Billing; also flags a missing webhook secret without blocking. |
| `sendgrid` | ready / blocked | Transactional email (reports, invitations) — policy-gated sends. |
| `linear` | ready / blocked | Optional PM task sync. |
| `abr` | ready / blocked | ABR GUID for ABN validation/lookup — optional. |
| `sentry` | connected / unknown | `NEXT_PUBLIC_SENTRY_DSN` is the only DSN var actually read by this repo's `sentry.*.config.ts` files. |
| `unite_group` | ready (fixed) | Final manifest entry per the standard shape — points back at this endpoint for the Mission Control registry. |

## Verification

- `npx tsc --noEmit -p tsconfig.json` → clean, no errors `[VERIFIED]`
- `npx eslint lib/connections/status.ts app/api/v1/connections/status/route.ts tests/unit/connections/status.test.ts` → clean, no errors `[VERIFIED]`
- `npx vitest run tests/unit/connections/status.test.ts` → 4/4 passed `[VERIFIED]`
  - empty-env → blocked/unknown states
  - full-env → connected/ready states
  - missing Stripe webhook secret → `ready` (not blocked) with `nextAction`
  - serialized payload contains none of the fixture secret values (no-leak assertion)

Tests were placed under `tests/unit/connections/` (not co-located `lib/connections/__tests__/`) because this repo's `vitest.config.ts` only includes `tests/**/*.{test,spec}.{ts,tsx}`.

## Scope

Only 3 new files added, nothing else touched:
- `lib/connections/status.ts`
- `app/api/v1/connections/status/route.ts`
- `tests/unit/connections/status.test.ts`

Opened as draft per the standing agent-PR rule.

🤖 Generated with [Claude Code](https://claude.com/claude-code)